### PR TITLE
Enhance Morpho dashboard with lending and borrowing summaries

### DIFF
--- a/components/PositionDisplay.tsx
+++ b/components/PositionDisplay.tsx
@@ -2,7 +2,12 @@
 
 import React from 'react';
 import { MarketPosition, HealthFactorData } from '@/types/morpho';
-import { formatUsdValue, formatTokenAmount, calculateHealthFactor, getHealthFactorColor } from '@/lib/calculations';
+import {
+  formatUsdValue,
+  formatTokenAmount,
+  calculateHealthFactor,
+  separatePositions,
+} from '@/lib/calculations';
 
 interface PositionDisplayProps {
   position: MarketPosition;
@@ -112,7 +117,7 @@ export function PositionList({ positions }: PositionListProps) {
   if (positions.length === 0) {
     return (
       <div className="bg-gray-50 rounded-lg p-8 text-center">
-        <p className="text-gray-600">No Morpho positions found on Base chain</p>
+        <p className="text-gray-600">No Morpho positions found on supported chains</p>
         <p className="text-sm text-gray-500 mt-2">
           Open positions on Morpho Blue to see them here
         </p>
@@ -120,11 +125,56 @@ export function PositionList({ positions }: PositionListProps) {
     );
   }
 
+  const { lendingPositions, borrowingPositions } = separatePositions(positions);
+
   return (
-    <div className="space-y-4">
-      {positions.map((position, index) => (
-        <PositionDisplay key={position.market.uniqueKey || index} position={position} />
-      ))}
+    <div className="space-y-6">
+      <PositionSection
+        title="Lending"
+        description="Deposits supplying liquidity to Morpho markets"
+        emptyMessage="No active lending positions"
+        positions={lendingPositions}
+      />
+
+      <PositionSection
+        title="Borrowing"
+        description="Loans currently taken against your collateral"
+        emptyMessage="No active borrowing positions"
+        positions={borrowingPositions}
+      />
     </div>
+  );
+}
+
+interface PositionSectionProps {
+  title: string;
+  description: string;
+  emptyMessage: string;
+  positions: MarketPosition[];
+}
+
+function PositionSection({ title, description, emptyMessage, positions }: PositionSectionProps) {
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h3 className="text-base font-semibold text-gray-900">{title}</h3>
+          <p className="text-xs text-gray-500">{description}</p>
+        </div>
+        <span className="text-xs text-gray-500">{positions.length} markets</span>
+      </div>
+
+      {positions.length === 0 ? (
+        <div className="bg-gray-50 rounded-lg p-6 text-center text-sm text-gray-500">
+          {emptyMessage}
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {positions.map((position, index) => (
+            <PositionDisplay key={position.market.uniqueKey || index} position={position} />
+          ))}
+        </div>
+      )}
+    </section>
   );
 }

--- a/lib/minikit.ts
+++ b/lib/minikit.ts
@@ -27,7 +27,7 @@ export class MiniKitService {
     try {
       if (typeof window !== 'undefined') {
         if (MINI_APP_ID) {
-          MiniKit.install({ app_id: MINI_APP_ID });
+          MiniKit.install(MINI_APP_ID);
         } else {
           MiniKit.install();
         }

--- a/lib/minikit.ts
+++ b/lib/minikit.ts
@@ -1,5 +1,7 @@
 import { MiniKit } from '@worldcoin/minikit-js';
 
+const MINI_APP_ID = process.env.NEXT_PUBLIC_MINI_APP_ID;
+
 export interface WalletAuthResult {
   success: boolean;
   address?: string;
@@ -23,6 +25,14 @@ export class MiniKitService {
     if (this.isInitialized) return;
 
     try {
+      if (typeof window !== 'undefined') {
+        if (MINI_APP_ID) {
+          MiniKit.install({ app_id: MINI_APP_ID });
+        } else {
+          MiniKit.install();
+        }
+      }
+
       // Initialize MiniKit - don't throw if not installed, just log
       console.log('MiniKit.isInstalled():', MiniKit.isInstalled());
       this.isInitialized = true;


### PR DESCRIPTION
## Summary
- add configurable MiniKit initialization and optional bypass for the World App environment check
- compute aggregate lending and borrowing metrics to drive new summary cards on the dashboard
- split the position list into dedicated lending and borrowing sections for clearer presentation

## Testing
- `npm run build` *(fails: Next.js cannot download the Inter font without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d9ac7f208320b938e66d96d868ad